### PR TITLE
Refactor GDAL library to be lazily loaded

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -6,78 +6,111 @@ from ctypes.util import find_library
 
 from django.contrib.gis.gdal.error import GDALException
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import SimpleLazyObject, lazy
 
 logger = logging.getLogger("django.contrib.gis")
 
-# Custom library path set?
-try:
-    from django.conf import settings
 
-    lib_path = settings.GDAL_LIBRARY_PATH
-except (AttributeError, ImportError, ImproperlyConfigured, OSError):
-    lib_path = None
+# Set library error handling so as errors are logged
+CPLErrorHandler = CFUNCTYPE(None, c_int, c_int, c_char_p)
 
-if lib_path:
-    lib_names = None
-elif os.name == "nt":
-    # Windows NT shared libraries
-    lib_names = [
-        "gdal310",
-        "gdal309",
-        "gdal308",
-        "gdal307",
-        "gdal306",
-        "gdal305",
-        "gdal304",
-        "gdal303",
-        "gdal302",
-        "gdal301",
-    ]
-elif os.name == "posix":
-    # *NIX library names.
-    lib_names = [
-        "gdal",
-        "GDAL",
-        "gdal3.10.0",
-        "gdal3.9.0",
-        "gdal3.8.0",
-        "gdal3.7.0",
-        "gdal3.6.0",
-        "gdal3.5.0",
-        "gdal3.4.0",
-        "gdal3.3.0",
-        "gdal3.2.0",
-        "gdal3.1.0",
-    ]
-else:
-    raise ImproperlyConfigured('GDAL is unsupported on OS "%s".' % os.name)
 
-# Using the ctypes `find_library` utility  to find the
-# path to the GDAL library from the list of library names.
-if lib_names:
-    for lib_name in lib_names:
-        lib_path = find_library(lib_name)
-        if lib_path is not None:
-            break
+def err_handler(error_class, error_number, message):
+    logger.error("GDAL_ERROR %d: %s", error_number, message)
 
-if lib_path is None:
-    raise ImproperlyConfigured(
-        'Could not find the GDAL library (tried "%s"). Is GDAL installed? '
-        "If it is, try setting GDAL_LIBRARY_PATH in your settings."
-        % '", "'.join(lib_names)
-    )
+
+err_handler = CPLErrorHandler(err_handler)
+
+
+def load_gdal():
+    # Custom library path set?
+    try:
+        from django.conf import settings
+
+        lib_path = settings.GDAL_LIBRARY_PATH
+    except (AttributeError, ImportError, ImproperlyConfigured, OSError):
+        lib_path = None
+
+    if lib_path:
+        lib_names = None
+    elif os.name == "nt":
+        # Windows NT shared libraries
+        lib_names = [
+            "gdal310",
+            "gdal309",
+            "gdal308",
+            "gdal307",
+            "gdal306",
+            "gdal305",
+            "gdal304",
+            "gdal303",
+            "gdal302",
+            "gdal301",
+        ]
+    elif os.name == "posix":
+        # *NIX library names.
+        lib_names = [
+            "gdal",
+            "GDAL",
+            "gdal3.10.0",
+            "gdal3.9.0",
+            "gdal3.8.0",
+            "gdal3.7.0",
+            "gdal3.6.0",
+            "gdal3.5.0",
+            "gdal3.4.0",
+            "gdal3.3.0",
+            "gdal3.2.0",
+            "gdal3.1.0",
+        ]
+    else:
+        raise ImproperlyConfigured('GDAL is unsupported on OS "%s".' % os.name)
+
+    # Using the ctypes `find_library` utility  to find the
+    # path to the GDAL library from the list of library names.
+    if lib_names:
+        for lib_name in lib_names:
+            lib_path = find_library(lib_name)
+            if lib_path is not None:
+                break
+
+    if lib_path is None:
+        raise ImproperlyConfigured(
+            'Could not find the GDAL library (tried "%s"). Is GDAL installed? '
+            "If it is, try setting GDAL_LIBRARY_PATH in your settings."
+            % '", "'.join(lib_names)
+        )
+
+    # Load the library
+    lib = CDLL(lib_path)
+
+    # Set up error handler after library is loaded
+    # We do this directly here to avoid circular dependency
+    set_error_handler_func = lib["CPLSetErrorHandler"]
+    set_error_handler_func.argtypes = [CPLErrorHandler]
+    set_error_handler_func.restype = CPLErrorHandler
+    set_error_handler_func(err_handler)
+
+    return lib
+
 
 # This loads the GDAL/OGR C library
-lgdal = CDLL(lib_path)
+lgdal = SimpleLazyObject(load_gdal)
+
+
+def load_wingdal():
+    from ctypes import WinDLL  # type: ignore[attr-defined]
+
+    lib_path = getattr(lgdal, "_name", None)
+    return WinDLL(lib_path)
+
 
 # On Windows, the GDAL binaries have some OSR routines exported with
 # STDCALL, while others are not.  Thus, the library will also need to
 # be loaded up as WinDLL for said OSR functions that require the
 # different calling convention.
 if os.name == "nt":
-    from ctypes import WinDLL
-
-    lwingdal = WinDLL(lib_path)
+    lwingdal = SimpleLazyObject(load_wingdal)
 
 
 def std_call(func):
@@ -91,12 +124,47 @@ def std_call(func):
         return lgdal[func]
 
 
+class GDALFuncFactory:
+    """
+    Lazy loading of GDAL functions.
+    """
+
+    argtypes = None
+    restype = None
+    errcheck = None
+
+    def __init__(self, func_name, *, restype=None, errcheck=None, argtypes=None):
+        self.func_name = func_name
+        if restype is not None:
+            self.restype = restype
+        if errcheck is not None:
+            self.errcheck = errcheck
+        if argtypes is not None:
+            self.argtypes = argtypes
+
+    def __call__(self, *args):
+        return self.func(*args)
+
+    @property
+    def func(self):
+        func = std_call(self.func_name)
+
+        # Setting the argument and return types.
+        if self.argtypes is not None:
+            func.argtypes = self.argtypes
+        if self.restype is not None:
+            func.restype = self.restype
+        if self.errcheck:
+            func.errcheck = self.errcheck
+        return func
+
+
 # #### Version-information functions. ####
 
 # Return GDAL library version information with the given key.
-_version_info = std_call("GDALVersionInfo")
-_version_info.argtypes = [c_char_p]
-_version_info.restype = c_char_p
+_version_info = GDALFuncFactory(
+    "GDALVersionInfo", argtypes=[c_char_p], restype=c_char_p
+)
 
 
 def gdal_version():
@@ -118,25 +186,4 @@ def gdal_version_info():
     return (int(major), int(minor), subminor and int(subminor))
 
 
-GDAL_VERSION = gdal_version_info()
-
-# Set library error handling so as errors are logged
-CPLErrorHandler = CFUNCTYPE(None, c_int, c_int, c_char_p)
-
-
-def err_handler(error_class, error_number, message):
-    logger.error("GDAL_ERROR %d: %s", error_number, message)
-
-
-err_handler = CPLErrorHandler(err_handler)
-
-
-def function(name, args, restype):
-    func = std_call(name)
-    func.argtypes = args
-    func.restype = restype
-    return func
-
-
-set_error_handler = function("CPLSetErrorHandler", [CPLErrorHandler], CPLErrorHandler)
-set_error_handler(err_handler)
+GDAL_VERSION = lazy(gdal_version_info, tuple)()

--- a/django/contrib/gis/gdal/prototypes/ds.py
+++ b/django/contrib/gis/gdal/prototypes/ds.py
@@ -7,17 +7,16 @@ OGR_Fld_* routines are relevant here.
 from ctypes import POINTER, c_char_p, c_double, c_int, c_long, c_uint, c_void_p
 
 from django.contrib.gis.gdal.envelope import OGREnvelope
-from django.contrib.gis.gdal.libgdal import lgdal
 from django.contrib.gis.gdal.prototypes.generation import (
-    bool_output,
-    const_string_output,
-    double_output,
-    geom_output,
-    int64_output,
-    int_output,
-    srs_output,
-    void_output,
-    voidptr_output,
+    BoolOutput,
+    ConstStringOutput,
+    DoubleOutput,
+    GeomOutput,
+    Int64Output,
+    IntOutput,
+    SRSOutput,
+    VoidOutput,
+    VoidPtrOutput,
 )
 
 c_int_p = POINTER(c_int)  # shortcut type
@@ -30,81 +29,90 @@ GDAL_OF_RASTER = 0x02
 GDAL_OF_VECTOR = 0x04
 
 # Driver Routines
-register_all = void_output(lgdal.GDALAllRegister, [], errcheck=False)
-cleanup_all = void_output(lgdal.GDALDestroyDriverManager, [], errcheck=False)
-get_driver = voidptr_output(lgdal.GDALGetDriver, [c_int])
-get_driver_by_name = voidptr_output(
-    lgdal.GDALGetDriverByName, [c_char_p], errcheck=False
+register_all = VoidOutput("GDALAllRegister", argtypes=[], errcheck=False)
+cleanup_all = VoidOutput("GDALDestroyDriverManager", argtypes=[], errcheck=False)
+get_driver = VoidPtrOutput("GDALGetDriver", argtypes=[c_int])
+get_driver_by_name = VoidPtrOutput(
+    "GDALGetDriverByName", argtypes=[c_char_p], errcheck=False
 )
-get_driver_count = int_output(lgdal.GDALGetDriverCount, [])
-get_driver_description = const_string_output(lgdal.GDALGetDescription, [c_void_p])
+get_driver_count = IntOutput("GDALGetDriverCount", argtypes=[])
+get_driver_description = ConstStringOutput("GDALGetDescription", argtypes=[c_void_p])
 
 # DataSource
-open_ds = voidptr_output(
-    lgdal.GDALOpenEx,
-    [c_char_p, c_uint, POINTER(c_char_p), POINTER(c_char_p), POINTER(c_char_p)],
+open_ds = VoidPtrOutput(
+    "GDALOpenEx",
+    argtypes=[
+        c_char_p,
+        c_uint,
+        POINTER(c_char_p),
+        POINTER(c_char_p),
+        POINTER(c_char_p),
+    ],
 )
-destroy_ds = void_output(lgdal.GDALClose, [c_void_p], errcheck=False)
-get_ds_name = const_string_output(lgdal.GDALGetDescription, [c_void_p])
-get_dataset_driver = voidptr_output(lgdal.GDALGetDatasetDriver, [c_void_p])
-get_layer = voidptr_output(lgdal.GDALDatasetGetLayer, [c_void_p, c_int])
-get_layer_by_name = voidptr_output(
-    lgdal.GDALDatasetGetLayerByName, [c_void_p, c_char_p]
+destroy_ds = VoidOutput("GDALClose", argtypes=[c_void_p], errcheck=False)
+get_ds_name = ConstStringOutput("GDALGetDescription", argtypes=[c_void_p])
+get_dataset_driver = VoidPtrOutput("GDALGetDatasetDriver", argtypes=[c_void_p])
+get_layer = VoidPtrOutput("GDALDatasetGetLayer", argtypes=[c_void_p, c_int])
+get_layer_by_name = VoidPtrOutput(
+    "GDALDatasetGetLayerByName", argtypes=[c_void_p, c_char_p]
 )
-get_layer_count = int_output(lgdal.GDALDatasetGetLayerCount, [c_void_p])
+get_layer_count = IntOutput("GDALDatasetGetLayerCount", argtypes=[c_void_p])
+
 
 # Layer Routines
-get_extent = void_output(lgdal.OGR_L_GetExtent, [c_void_p, POINTER(OGREnvelope), c_int])
-get_feature = voidptr_output(lgdal.OGR_L_GetFeature, [c_void_p, c_long])
-get_feature_count = int_output(lgdal.OGR_L_GetFeatureCount, [c_void_p, c_int])
-get_layer_defn = voidptr_output(lgdal.OGR_L_GetLayerDefn, [c_void_p])
-get_layer_srs = srs_output(lgdal.OGR_L_GetSpatialRef, [c_void_p])
-get_next_feature = voidptr_output(lgdal.OGR_L_GetNextFeature, [c_void_p])
-reset_reading = void_output(lgdal.OGR_L_ResetReading, [c_void_p], errcheck=False)
-test_capability = int_output(lgdal.OGR_L_TestCapability, [c_void_p, c_char_p])
-get_spatial_filter = geom_output(lgdal.OGR_L_GetSpatialFilter, [c_void_p])
-set_spatial_filter = void_output(
-    lgdal.OGR_L_SetSpatialFilter, [c_void_p, c_void_p], errcheck=False
+get_extent = VoidOutput(
+    "OGR_L_GetExtent", argtypes=[c_void_p, POINTER(OGREnvelope), c_int]
 )
-set_spatial_filter_rect = void_output(
-    lgdal.OGR_L_SetSpatialFilterRect,
-    [c_void_p, c_double, c_double, c_double, c_double],
+get_feature = VoidPtrOutput("OGR_L_GetFeature", argtypes=[c_void_p, c_long])
+get_feature_count = IntOutput("OGR_L_GetFeatureCount", argtypes=[c_void_p, c_int])
+get_layer_defn = VoidPtrOutput("OGR_L_GetLayerDefn", argtypes=[c_void_p])
+get_layer_srs = SRSOutput("OGR_L_GetSpatialRef", argtypes=[c_void_p])
+get_next_feature = VoidPtrOutput("OGR_L_GetNextFeature", argtypes=[c_void_p])
+reset_reading = VoidOutput("OGR_L_ResetReading", argtypes=[c_void_p], errcheck=False)
+test_capability = IntOutput("OGR_L_TestCapability", argtypes=[c_void_p, c_char_p])
+get_spatial_filter = GeomOutput("OGR_L_GetSpatialFilter", argtypes=[c_void_p])
+set_spatial_filter = VoidOutput(
+    "OGR_L_SetSpatialFilter", argtypes=[c_void_p, c_void_p], errcheck=False
+)
+set_spatial_filter_rect = VoidOutput(
+    "OGR_L_SetSpatialFilterRect",
+    argtypes=[c_void_p, c_double, c_double, c_double, c_double],
     errcheck=False,
 )
 
 # Feature Definition Routines
-get_fd_geom_type = int_output(lgdal.OGR_FD_GetGeomType, [c_void_p])
-get_fd_name = const_string_output(lgdal.OGR_FD_GetName, [c_void_p])
-get_feat_name = const_string_output(lgdal.OGR_FD_GetName, [c_void_p])
-get_field_count = int_output(lgdal.OGR_FD_GetFieldCount, [c_void_p])
-get_field_defn = voidptr_output(lgdal.OGR_FD_GetFieldDefn, [c_void_p, c_int])
+get_fd_geom_type = IntOutput("OGR_FD_GetGeomType", argtypes=[c_void_p])
+get_fd_name = ConstStringOutput("OGR_FD_GetName", argtypes=[c_void_p])
+get_feat_name = ConstStringOutput("OGR_FD_GetName", argtypes=[c_void_p])
+get_field_count = IntOutput("OGR_FD_GetFieldCount", argtypes=[c_void_p])
+get_field_defn = VoidPtrOutput("OGR_FD_GetFieldDefn", argtypes=[c_void_p, c_int])
 
 # Feature Routines
-clone_feature = voidptr_output(lgdal.OGR_F_Clone, [c_void_p])
-destroy_feature = void_output(lgdal.OGR_F_Destroy, [c_void_p], errcheck=False)
-feature_equal = int_output(lgdal.OGR_F_Equal, [c_void_p, c_void_p])
-get_feat_geom_ref = geom_output(lgdal.OGR_F_GetGeometryRef, [c_void_p])
-get_feat_field_count = int_output(lgdal.OGR_F_GetFieldCount, [c_void_p])
-get_feat_field_defn = voidptr_output(lgdal.OGR_F_GetFieldDefnRef, [c_void_p, c_int])
-get_fid = int_output(lgdal.OGR_F_GetFID, [c_void_p])
-get_field_as_datetime = int_output(
-    lgdal.OGR_F_GetFieldAsDateTime,
-    [c_void_p, c_int, c_int_p, c_int_p, c_int_p, c_int_p, c_int_p, c_int_p],
+clone_feature = VoidPtrOutput("OGR_F_Clone", argtypes=[c_void_p])
+destroy_feature = VoidOutput("OGR_F_Destroy", argtypes=[c_void_p], errcheck=False)
+feature_equal = IntOutput("OGR_F_Equal", argtypes=[c_void_p, c_void_p])
+get_feat_geom_ref = GeomOutput("OGR_F_GetGeometryRef", argtypes=[c_void_p])
+get_feat_field_count = IntOutput("OGR_F_GetFieldCount", argtypes=[c_void_p])
+get_feat_field_defn = VoidPtrOutput("OGR_F_GetFieldDefnRef", argtypes=[c_void_p, c_int])
+get_fid = IntOutput("OGR_F_GetFID", argtypes=[c_void_p])
+get_field_as_datetime = IntOutput(
+    "OGR_F_GetFieldAsDateTime",
+    argtypes=[c_void_p, c_int, c_int_p, c_int_p, c_int_p, c_int_p, c_int_p, c_int_p],
 )
-get_field_as_double = double_output(lgdal.OGR_F_GetFieldAsDouble, [c_void_p, c_int])
-get_field_as_integer = int_output(lgdal.OGR_F_GetFieldAsInteger, [c_void_p, c_int])
-get_field_as_integer64 = int64_output(
-    lgdal.OGR_F_GetFieldAsInteger64, [c_void_p, c_int]
+get_field_as_double = DoubleOutput("OGR_F_GetFieldAsDouble", argtypes=[c_void_p, c_int])
+get_field_as_integer = IntOutput("OGR_F_GetFieldAsInteger", argtypes=[c_void_p, c_int])
+get_field_as_integer64 = Int64Output(
+    "OGR_F_GetFieldAsInteger64", argtypes=[c_void_p, c_int]
 )
-is_field_set = bool_output(lgdal.OGR_F_IsFieldSetAndNotNull, [c_void_p, c_int])
-get_field_as_string = const_string_output(
-    lgdal.OGR_F_GetFieldAsString, [c_void_p, c_int]
+is_field_set = BoolOutput("OGR_F_IsFieldSetAndNotNull", argtypes=[c_void_p, c_int])
+get_field_as_string = ConstStringOutput(
+    "OGR_F_GetFieldAsString", argtypes=[c_void_p, c_int]
 )
-get_field_index = int_output(lgdal.OGR_F_GetFieldIndex, [c_void_p, c_char_p])
+get_field_index = IntOutput("OGR_F_GetFieldIndex", argtypes=[c_void_p, c_char_p])
 
 # Field Routines
-get_field_name = const_string_output(lgdal.OGR_Fld_GetNameRef, [c_void_p])
-get_field_precision = int_output(lgdal.OGR_Fld_GetPrecision, [c_void_p])
-get_field_type = int_output(lgdal.OGR_Fld_GetType, [c_void_p])
-get_field_type_name = const_string_output(lgdal.OGR_GetFieldTypeName, [c_int])
-get_field_width = int_output(lgdal.OGR_Fld_GetWidth, [c_void_p])
+get_field_name = ConstStringOutput("OGR_Fld_GetNameRef", argtypes=[c_void_p])
+get_field_precision = IntOutput("OGR_Fld_GetPrecision", argtypes=[c_void_p])
+get_field_type = IntOutput("OGR_Fld_GetType", argtypes=[c_void_p])
+get_field_type_name = ConstStringOutput("OGR_GetFieldTypeName", argtypes=[c_int])
+get_field_width = IntOutput("OGR_Fld_GetWidth", argtypes=[c_void_p])

--- a/django/contrib/gis/gdal/prototypes/geom.py
+++ b/django/contrib/gis/gdal/prototypes/geom.py
@@ -1,151 +1,186 @@
 from ctypes import POINTER, c_char_p, c_double, c_int, c_void_p
 
 from django.contrib.gis.gdal.envelope import OGREnvelope
-from django.contrib.gis.gdal.libgdal import GDAL_VERSION, lgdal
+from django.contrib.gis.gdal.libgdal import GDALFuncFactory
 from django.contrib.gis.gdal.prototypes.errcheck import check_envelope
 from django.contrib.gis.gdal.prototypes.generation import (
-    bool_output,
-    const_string_output,
-    double_output,
-    geom_output,
-    int_output,
-    srs_output,
-    string_output,
-    void_output,
+    BoolOutput,
+    ConstStringOutput,
+    DoubleOutput,
+    GeomOutput,
+    IntOutput,
+    SRSOutput,
+    StringOutput,
+    VoidOutput,
 )
+from django.utils.functional import cached_property
+
+
+class LazyGeomFunction:
+    """A wrapper that lazily creates geometry functions based on GDAL version."""
+
+    def __init__(self, func):
+        self._func = func
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    @cached_property
+    def func(self):
+        return self._func()
 
 
 # ### Generation routines specific to this module ###
-def env_func(f, argtypes):
-    "For getting OGREnvelopes."
-    f.argtypes = argtypes
-    f.restype = None
-    f.errcheck = check_envelope
-    return f
+class EnvFunc(GDALFuncFactory):
+    """For getting OGREnvelopes."""
+
+    restype = None
+    errcheck = staticmethod(check_envelope)
 
 
-def pnt_func(f):
-    "For accessing point information."
-    return double_output(f, [c_void_p, c_int])
+class PntFunc(GDALFuncFactory):
+    """For accessing point information."""
+
+    argtypes = [c_void_p, c_int]
+    restype = c_double
 
 
-def topology_func(f):
-    f.argtypes = [c_void_p, c_void_p]
-    f.restype = c_int
-    f.errcheck = lambda result, func, cargs: bool(result)
-    return f
+class TopologyFunc(GDALFuncFactory):
+    """For topology functions."""
+
+    argtypes = [c_void_p, c_void_p]
+    restype = c_int
+    errcheck = staticmethod(lambda result, func, cargs: bool(result))
 
 
 # ### OGR_G ctypes function prototypes ###
 
 # GeoJSON routines.
-from_json = geom_output(lgdal.OGR_G_CreateGeometryFromJson, [c_char_p])
-to_json = string_output(
-    lgdal.OGR_G_ExportToJson, [c_void_p], str_result=True, decoding="ascii"
+from_json = GeomOutput("OGR_G_CreateGeometryFromJson", argtypes=[c_char_p])
+to_json = StringOutput(
+    "OGR_G_ExportToJson", argtypes=[c_void_p], str_result=True, decoding="ascii"
 )
-to_kml = string_output(
-    lgdal.OGR_G_ExportToKML, [c_void_p, c_char_p], str_result=True, decoding="ascii"
+to_kml = StringOutput(
+    "OGR_G_ExportToKML",
+    argtypes=[c_void_p, c_char_p],
+    str_result=True,
+    decoding="ascii",
 )
 
 # GetX, GetY, GetZ all return doubles.
-getx = pnt_func(lgdal.OGR_G_GetX)
-gety = pnt_func(lgdal.OGR_G_GetY)
-getz = pnt_func(lgdal.OGR_G_GetZ)
-getm = pnt_func(lgdal.OGR_G_GetM)
+getx = PntFunc("OGR_G_GetX")
+gety = PntFunc("OGR_G_GetY")
+getz = PntFunc("OGR_G_GetZ")
+getm = PntFunc("OGR_G_GetM")
+
 
 # Geometry creation routines.
-if GDAL_VERSION >= (3, 3):
-    from_wkb = geom_output(
-        lgdal.OGR_G_CreateFromWkbEx,
-        [c_char_p, c_void_p, POINTER(c_void_p), c_int],
-        offset=-2,
-    )
-else:
-    from_wkb = geom_output(
-        lgdal.OGR_G_CreateFromWkb,
-        [c_char_p, c_void_p, POINTER(c_void_p), c_int],
-        offset=-2,
-    )
-from_wkt = geom_output(
-    lgdal.OGR_G_CreateFromWkt,
-    [POINTER(c_char_p), c_void_p, POINTER(c_void_p)],
+def _from_wkb():
+    from django.contrib.gis.gdal.libgdal import GDAL_VERSION
+
+    if GDAL_VERSION >= (3, 3):
+        return GeomOutput(
+            "OGR_G_CreateFromWkbEx",
+            argtypes=[c_char_p, c_void_p, POINTER(c_void_p), c_int],
+            offset=-2,
+        )
+    else:
+        return GeomOutput(
+            "OGR_G_CreateFromWkb",
+            argtypes=[c_char_p, c_void_p, POINTER(c_void_p), c_int],
+            offset=-2,
+        )
+
+
+from_wkb = LazyGeomFunction(_from_wkb)
+from_wkt = GeomOutput(
+    "OGR_G_CreateFromWkt",
+    argtypes=[POINTER(c_char_p), c_void_p, POINTER(c_void_p)],
     offset=-1,
 )
-from_gml = geom_output(lgdal.OGR_G_CreateFromGML, [c_char_p])
-create_geom = geom_output(lgdal.OGR_G_CreateGeometry, [c_int])
-clone_geom = geom_output(lgdal.OGR_G_Clone, [c_void_p])
-get_geom_ref = geom_output(lgdal.OGR_G_GetGeometryRef, [c_void_p, c_int])
-get_boundary = geom_output(lgdal.OGR_G_GetBoundary, [c_void_p])
-geom_convex_hull = geom_output(lgdal.OGR_G_ConvexHull, [c_void_p])
-geom_diff = geom_output(lgdal.OGR_G_Difference, [c_void_p, c_void_p])
-geom_intersection = geom_output(lgdal.OGR_G_Intersection, [c_void_p, c_void_p])
-geom_sym_diff = geom_output(lgdal.OGR_G_SymmetricDifference, [c_void_p, c_void_p])
-geom_union = geom_output(lgdal.OGR_G_Union, [c_void_p, c_void_p])
-is_3d = bool_output(lgdal.OGR_G_Is3D, [c_void_p])
-set_3d = void_output(lgdal.OGR_G_Set3D, [c_void_p, c_int], errcheck=False)
-is_measured = bool_output(lgdal.OGR_G_IsMeasured, [c_void_p])
-set_measured = void_output(lgdal.OGR_G_SetMeasured, [c_void_p, c_int], errcheck=False)
-has_curve_geom = bool_output(lgdal.OGR_G_HasCurveGeometry, [c_void_p, c_int])
-get_linear_geom = geom_output(
-    lgdal.OGR_G_GetLinearGeometry, [c_void_p, c_double, POINTER(c_char_p)]
+from_gml = GeomOutput("OGR_G_CreateFromGML", argtypes=[c_char_p])
+create_geom = GeomOutput("OGR_G_CreateGeometry", argtypes=[c_int])
+clone_geom = GeomOutput("OGR_G_Clone", argtypes=[c_void_p])
+get_geom_ref = GeomOutput("OGR_G_GetGeometryRef", argtypes=[c_void_p, c_int])
+get_boundary = GeomOutput("OGR_G_GetBoundary", argtypes=[c_void_p])
+geom_convex_hull = GeomOutput("OGR_G_ConvexHull", argtypes=[c_void_p])
+geom_diff = GeomOutput("OGR_G_Difference", argtypes=[c_void_p, c_void_p])
+geom_intersection = GeomOutput("OGR_G_Intersection", argtypes=[c_void_p, c_void_p])
+geom_sym_diff = GeomOutput("OGR_G_SymmetricDifference", argtypes=[c_void_p, c_void_p])
+geom_union = GeomOutput("OGR_G_Union", argtypes=[c_void_p, c_void_p])
+is_3d = BoolOutput("OGR_G_Is3D", argtypes=[c_void_p])
+set_3d = VoidOutput("OGR_G_Set3D", argtypes=[c_void_p, c_int], errcheck=False)
+is_measured = BoolOutput("OGR_G_IsMeasured", argtypes=[c_void_p])
+set_measured = VoidOutput(
+    "OGR_G_SetMeasured", argtypes=[c_void_p, c_int], errcheck=False
 )
-get_curve_geom = geom_output(
-    lgdal.OGR_G_GetCurveGeometry, [c_void_p, POINTER(c_char_p)]
+has_curve_geom = BoolOutput("OGR_G_HasCurveGeometry", argtypes=[c_void_p, c_int])
+get_linear_geom = GeomOutput(
+    "OGR_G_GetLinearGeometry", argtypes=[c_void_p, c_double, POINTER(c_char_p)]
+)
+get_curve_geom = GeomOutput(
+    "OGR_G_GetCurveGeometry", argtypes=[c_void_p, POINTER(c_char_p)]
 )
 
 # Geometry modification routines.
-add_geom = void_output(lgdal.OGR_G_AddGeometry, [c_void_p, c_void_p])
-import_wkt = void_output(lgdal.OGR_G_ImportFromWkt, [c_void_p, POINTER(c_char_p)])
+add_geom = VoidOutput("OGR_G_AddGeometry", argtypes=[c_void_p, c_void_p])
+import_wkt = VoidOutput("OGR_G_ImportFromWkt", argtypes=[c_void_p, POINTER(c_char_p)])
 
 # Destroys a geometry
-destroy_geom = void_output(lgdal.OGR_G_DestroyGeometry, [c_void_p], errcheck=False)
+destroy_geom = VoidOutput("OGR_G_DestroyGeometry", argtypes=[c_void_p], errcheck=False)
 
 # Geometry export routines.
-to_wkb = void_output(
-    lgdal.OGR_G_ExportToWkb, None, errcheck=True
+to_wkb = VoidOutput(
+    "OGR_G_ExportToWkb", argtypes=None, errcheck=True
 )  # special handling for WKB.
-to_iso_wkb = void_output(lgdal.OGR_G_ExportToIsoWkb, None, errcheck=True)
-to_wkt = string_output(
-    lgdal.OGR_G_ExportToWkt, [c_void_p, POINTER(c_char_p)], decoding="ascii"
+to_iso_wkb = VoidOutput("OGR_G_ExportToIsoWkb", argtypes=None, errcheck=True)
+to_wkt = StringOutput(
+    "OGR_G_ExportToWkt", argtypes=[c_void_p, POINTER(c_char_p)], decoding="ascii"
 )
-to_iso_wkt = string_output(
-    lgdal.OGR_G_ExportToIsoWkt, [c_void_p, POINTER(c_char_p)], decoding="ascii"
+to_iso_wkt = StringOutput(
+    "OGR_G_ExportToIsoWkt", argtypes=[c_void_p, POINTER(c_char_p)], decoding="ascii"
 )
-to_gml = string_output(
-    lgdal.OGR_G_ExportToGML, [c_void_p], str_result=True, decoding="ascii"
+to_gml = StringOutput(
+    "OGR_G_ExportToGML", argtypes=[c_void_p], str_result=True, decoding="ascii"
 )
-if GDAL_VERSION >= (3, 3):
-    get_wkbsize = int_output(lgdal.OGR_G_WkbSizeEx, [c_void_p])
-else:
-    get_wkbsize = int_output(lgdal.OGR_G_WkbSize, [c_void_p])
+
+
+def _get_wkbsize():
+    from django.contrib.gis.gdal.libgdal import GDAL_VERSION
+
+    if GDAL_VERSION >= (3, 3):
+        return IntOutput("OGR_G_WkbSizeEx", argtypes=[c_void_p])
+    else:
+        return IntOutput("OGR_G_WkbSize", argtypes=[c_void_p])
+
+
+get_wkbsize = LazyGeomFunction(_get_wkbsize)
 
 # Geometry spatial-reference related routines.
-assign_srs = void_output(
-    lgdal.OGR_G_AssignSpatialReference, [c_void_p, c_void_p], errcheck=False
+assign_srs = VoidOutput(
+    "OGR_G_AssignSpatialReference", argtypes=[c_void_p, c_void_p], errcheck=False
 )
-get_geom_srs = srs_output(lgdal.OGR_G_GetSpatialReference, [c_void_p])
+get_geom_srs = SRSOutput("OGR_G_GetSpatialReference", argtypes=[c_void_p])
 
 # Geometry properties
-get_area = double_output(lgdal.OGR_G_GetArea, [c_void_p])
-get_centroid = void_output(lgdal.OGR_G_Centroid, [c_void_p, c_void_p])
-get_dims = int_output(lgdal.OGR_G_GetDimension, [c_void_p])
-get_coord_dim = int_output(lgdal.OGR_G_CoordinateDimension, [c_void_p])
-set_coord_dim = void_output(
-    lgdal.OGR_G_SetCoordinateDimension, [c_void_p, c_int], errcheck=False
+get_area = DoubleOutput("OGR_G_GetArea", argtypes=[c_void_p])
+get_centroid = VoidOutput("OGR_G_Centroid", argtypes=[c_void_p, c_void_p])
+get_dims = IntOutput("OGR_G_GetDimension", argtypes=[c_void_p])
+get_coord_dim = IntOutput("OGR_G_CoordinateDimension", argtypes=[c_void_p])
+set_coord_dim = VoidOutput(
+    "OGR_G_SetCoordinateDimension", argtypes=[c_void_p, c_int], errcheck=False
 )
-is_empty = int_output(
-    lgdal.OGR_G_IsEmpty, [c_void_p], errcheck=lambda result, func, cargs: bool(result)
-)
+is_empty = BoolOutput("OGR_G_IsEmpty", argtypes=[c_void_p])
 
-get_geom_count = int_output(lgdal.OGR_G_GetGeometryCount, [c_void_p])
-get_geom_name = const_string_output(
-    lgdal.OGR_G_GetGeometryName, [c_void_p], decoding="ascii"
+get_geom_count = IntOutput("OGR_G_GetGeometryCount", argtypes=[c_void_p])
+get_geom_name = ConstStringOutput(
+    "OGR_G_GetGeometryName", argtypes=[c_void_p], decoding="ascii"
 )
-get_geom_type = int_output(lgdal.OGR_G_GetGeometryType, [c_void_p])
-get_point_count = int_output(lgdal.OGR_G_GetPointCount, [c_void_p])
-get_point = void_output(
-    lgdal.OGR_G_GetPointZM,
-    [
+get_geom_type = IntOutput("OGR_G_GetGeometryType", argtypes=[c_void_p])
+get_point_count = IntOutput("OGR_G_GetPointCount", argtypes=[c_void_p])
+get_point = VoidOutput(
+    "OGR_G_GetPointZM",
+    argtypes=[
         c_void_p,
         c_int,
         POINTER(c_double),
@@ -155,21 +190,21 @@ get_point = void_output(
     ],
     errcheck=False,
 )
-geom_close_rings = void_output(lgdal.OGR_G_CloseRings, [c_void_p], errcheck=False)
+geom_close_rings = VoidOutput("OGR_G_CloseRings", argtypes=[c_void_p], errcheck=False)
 
 # Topology routines.
-ogr_contains = topology_func(lgdal.OGR_G_Contains)
-ogr_crosses = topology_func(lgdal.OGR_G_Crosses)
-ogr_disjoint = topology_func(lgdal.OGR_G_Disjoint)
-ogr_equals = topology_func(lgdal.OGR_G_Equals)
-ogr_intersects = topology_func(lgdal.OGR_G_Intersects)
-ogr_overlaps = topology_func(lgdal.OGR_G_Overlaps)
-ogr_touches = topology_func(lgdal.OGR_G_Touches)
-ogr_within = topology_func(lgdal.OGR_G_Within)
+ogr_contains = TopologyFunc("OGR_G_Contains")
+ogr_crosses = TopologyFunc("OGR_G_Crosses")
+ogr_disjoint = TopologyFunc("OGR_G_Disjoint")
+ogr_equals = TopologyFunc("OGR_G_Equals")
+ogr_intersects = TopologyFunc("OGR_G_Intersects")
+ogr_overlaps = TopologyFunc("OGR_G_Overlaps")
+ogr_touches = TopologyFunc("OGR_G_Touches")
+ogr_within = TopologyFunc("OGR_G_Within")
 
 # Transformation routines.
-geom_transform = void_output(lgdal.OGR_G_Transform, [c_void_p, c_void_p])
-geom_transform_to = void_output(lgdal.OGR_G_TransformTo, [c_void_p, c_void_p])
+geom_transform = VoidOutput("OGR_G_Transform", argtypes=[c_void_p, c_void_p])
+geom_transform_to = VoidOutput("OGR_G_TransformTo", argtypes=[c_void_p, c_void_p])
 
 # For retrieving the envelope of the geometry.
-get_envelope = env_func(lgdal.OGR_G_GetEnvelope, [c_void_p, POINTER(OGREnvelope)])
+get_envelope = EnvFunc("OGR_G_GetEnvelope", argtypes=[c_void_p, POINTER(OGREnvelope)])

--- a/django/contrib/gis/gdal/prototypes/raster.py
+++ b/django/contrib/gis/gdal/prototypes/raster.py
@@ -6,14 +6,13 @@ related data structures.
 from ctypes import POINTER, c_bool, c_char_p, c_double, c_int, c_void_p
 from functools import partial
 
-from django.contrib.gis.gdal.libgdal import std_call
 from django.contrib.gis.gdal.prototypes.generation import (
-    chararray_output,
-    const_string_output,
-    double_output,
-    int_output,
-    void_output,
-    voidptr_output,
+    CharArrayOutput,
+    ConstStringOutput,
+    DoubleOutput,
+    IntOutput,
+    VoidOutput,
+    VoidPtrOutput,
 )
 
 # For more detail about c function names and definitions see
@@ -22,61 +21,67 @@ from django.contrib.gis.gdal.prototypes.generation import (
 # https://gdal.org/api/gdal_utils.html
 
 # Prepare partial functions that use cpl error codes
-void_output = partial(void_output, cpl=True)
-const_string_output = partial(const_string_output, cpl=True)
-double_output = partial(double_output, cpl=True)
+VoidOutput = partial(VoidOutput, cpl=True)
+ConstStringOutput = partial(ConstStringOutput, cpl=True)
+DoubleOutput = partial(DoubleOutput, cpl=True)
 
 # Raster Data Source Routines
-create_ds = voidptr_output(
-    std_call("GDALCreate"), [c_void_p, c_char_p, c_int, c_int, c_int, c_int, c_void_p]
+create_ds = VoidPtrOutput(
+    "GDALCreate", argtypes=[c_void_p, c_char_p, c_int, c_int, c_int, c_int, c_void_p]
 )
-open_ds = voidptr_output(std_call("GDALOpen"), [c_char_p, c_int])
-close_ds = void_output(std_call("GDALClose"), [c_void_p], errcheck=False)
-flush_ds = int_output(std_call("GDALFlushCache"), [c_void_p])
-copy_ds = voidptr_output(
-    std_call("GDALCreateCopy"),
-    [c_void_p, c_char_p, c_void_p, c_int, POINTER(c_char_p), c_void_p, c_void_p],
+open_ds = VoidPtrOutput("GDALOpen", argtypes=[c_char_p, c_int])
+close_ds = VoidOutput("GDALClose", argtypes=[c_void_p], errcheck=False)
+flush_ds = IntOutput("GDALFlushCache", argtypes=[c_void_p])
+copy_ds = VoidPtrOutput(
+    "GDALCreateCopy",
+    argtypes=[
+        c_void_p,
+        c_char_p,
+        c_void_p,
+        c_int,
+        POINTER(c_char_p),
+        c_void_p,
+        c_void_p,
+    ],
 )
-add_band_ds = void_output(std_call("GDALAddBand"), [c_void_p, c_int])
-get_ds_description = const_string_output(std_call("GDALGetDescription"), [c_void_p])
-get_ds_driver = voidptr_output(std_call("GDALGetDatasetDriver"), [c_void_p])
-get_ds_info = const_string_output(std_call("GDALInfo"), [c_void_p, c_void_p])
-get_ds_xsize = int_output(std_call("GDALGetRasterXSize"), [c_void_p])
-get_ds_ysize = int_output(std_call("GDALGetRasterYSize"), [c_void_p])
-get_ds_raster_count = int_output(std_call("GDALGetRasterCount"), [c_void_p])
-get_ds_raster_band = voidptr_output(std_call("GDALGetRasterBand"), [c_void_p, c_int])
-get_ds_projection_ref = const_string_output(
-    std_call("GDALGetProjectionRef"), [c_void_p]
+add_band_ds = VoidOutput("GDALAddBand", argtypes=[c_void_p, c_int])
+get_ds_description = ConstStringOutput("GDALGetDescription", argtypes=[c_void_p])
+get_ds_driver = VoidPtrOutput("GDALGetDatasetDriver", argtypes=[c_void_p])
+get_ds_info = ConstStringOutput("GDALInfo", argtypes=[c_void_p, c_void_p])
+get_ds_xsize = IntOutput("GDALGetRasterXSize", argtypes=[c_void_p])
+get_ds_ysize = IntOutput("GDALGetRasterYSize", argtypes=[c_void_p])
+get_ds_raster_count = IntOutput("GDALGetRasterCount", argtypes=[c_void_p])
+get_ds_raster_band = VoidPtrOutput("GDALGetRasterBand", argtypes=[c_void_p, c_int])
+get_ds_projection_ref = ConstStringOutput("GDALGetProjectionRef", argtypes=[c_void_p])
+set_ds_projection_ref = VoidOutput("GDALSetProjection", argtypes=[c_void_p, c_char_p])
+get_ds_geotransform = VoidOutput(
+    "GDALGetGeoTransform", argtypes=[c_void_p, POINTER(c_double * 6)], errcheck=False
 )
-set_ds_projection_ref = void_output(std_call("GDALSetProjection"), [c_void_p, c_char_p])
-get_ds_geotransform = void_output(
-    std_call("GDALGetGeoTransform"), [c_void_p, POINTER(c_double * 6)], errcheck=False
-)
-set_ds_geotransform = void_output(
-    std_call("GDALSetGeoTransform"), [c_void_p, POINTER(c_double * 6)]
+set_ds_geotransform = VoidOutput(
+    "GDALSetGeoTransform", argtypes=[c_void_p, POINTER(c_double * 6)]
 )
 
-get_ds_metadata = chararray_output(
-    std_call("GDALGetMetadata"), [c_void_p, c_char_p], errcheck=False
+get_ds_metadata = CharArrayOutput(
+    "GDALGetMetadata", argtypes=[c_void_p, c_char_p], errcheck=False
 )
-set_ds_metadata = void_output(
-    std_call("GDALSetMetadata"), [c_void_p, POINTER(c_char_p), c_char_p]
+set_ds_metadata = VoidOutput(
+    "GDALSetMetadata", argtypes=[c_void_p, POINTER(c_char_p), c_char_p]
 )
-get_ds_metadata_domain_list = chararray_output(
-    std_call("GDALGetMetadataDomainList"), [c_void_p], errcheck=False
+get_ds_metadata_domain_list = CharArrayOutput(
+    "GDALGetMetadataDomainList", argtypes=[c_void_p], errcheck=False
 )
-get_ds_metadata_item = const_string_output(
-    std_call("GDALGetMetadataItem"), [c_void_p, c_char_p, c_char_p]
+get_ds_metadata_item = ConstStringOutput(
+    "GDALGetMetadataItem", argtypes=[c_void_p, c_char_p, c_char_p]
 )
-set_ds_metadata_item = const_string_output(
-    std_call("GDALSetMetadataItem"), [c_void_p, c_char_p, c_char_p, c_char_p]
+set_ds_metadata_item = ConstStringOutput(
+    "GDALSetMetadataItem", argtypes=[c_void_p, c_char_p, c_char_p, c_char_p]
 )
-free_dsl = void_output(std_call("CSLDestroy"), [POINTER(c_char_p)], errcheck=False)
+free_dsl = VoidOutput("CSLDestroy", argtypes=[POINTER(c_char_p)], errcheck=False)
 
 # Raster Band Routines
-band_io = void_output(
-    std_call("GDALRasterIO"),
-    [
+band_io = VoidOutput(
+    "GDALRasterIO",
+    argtypes=[
         c_void_p,
         c_int,
         c_int,
@@ -91,27 +96,27 @@ band_io = void_output(
         c_int,
     ],
 )
-get_band_xsize = int_output(std_call("GDALGetRasterBandXSize"), [c_void_p])
-get_band_ysize = int_output(std_call("GDALGetRasterBandYSize"), [c_void_p])
-get_band_index = int_output(std_call("GDALGetBandNumber"), [c_void_p])
-get_band_description = const_string_output(std_call("GDALGetDescription"), [c_void_p])
-get_band_ds = voidptr_output(std_call("GDALGetBandDataset"), [c_void_p])
-get_band_datatype = int_output(std_call("GDALGetRasterDataType"), [c_void_p])
-get_band_color_interp = int_output(
-    std_call("GDALGetRasterColorInterpretation"), [c_void_p]
+get_band_xsize = IntOutput("GDALGetRasterBandXSize", argtypes=[c_void_p])
+get_band_ysize = IntOutput("GDALGetRasterBandYSize", argtypes=[c_void_p])
+get_band_index = IntOutput("GDALGetBandNumber", argtypes=[c_void_p])
+get_band_description = ConstStringOutput("GDALGetDescription", argtypes=[c_void_p])
+get_band_ds = VoidPtrOutput("GDALGetBandDataset", argtypes=[c_void_p])
+get_band_datatype = IntOutput("GDALGetRasterDataType", argtypes=[c_void_p])
+get_band_color_interp = IntOutput(
+    "GDALGetRasterColorInterpretation", argtypes=[c_void_p]
 )
-get_band_nodata_value = double_output(
-    std_call("GDALGetRasterNoDataValue"), [c_void_p, POINTER(c_int)]
+get_band_nodata_value = DoubleOutput(
+    "GDALGetRasterNoDataValue", argtypes=[c_void_p, POINTER(c_int)]
 )
-set_band_nodata_value = void_output(
-    std_call("GDALSetRasterNoDataValue"), [c_void_p, c_double]
+set_band_nodata_value = VoidOutput(
+    "GDALSetRasterNoDataValue", argtypes=[c_void_p, c_double]
 )
-delete_band_nodata_value = void_output(
-    std_call("GDALDeleteRasterNoDataValue"), [c_void_p]
+delete_band_nodata_value = VoidOutput(
+    "GDALDeleteRasterNoDataValue", argtypes=[c_void_p]
 )
-get_band_statistics = void_output(
-    std_call("GDALGetRasterStatistics"),
-    [
+get_band_statistics = VoidOutput(
+    "GDALGetRasterStatistics",
+    argtypes=[
         c_void_p,
         c_int,
         c_int,
@@ -123,9 +128,9 @@ get_band_statistics = void_output(
         c_void_p,
     ],
 )
-compute_band_statistics = void_output(
-    std_call("GDALComputeRasterStatistics"),
-    [
+compute_band_statistics = VoidOutput(
+    "GDALComputeRasterStatistics",
+    argtypes=[
         c_void_p,
         c_int,
         POINTER(c_double),
@@ -138,9 +143,9 @@ compute_band_statistics = void_output(
 )
 
 # Reprojection routine
-reproject_image = void_output(
-    std_call("GDALReprojectImage"),
-    [
+reproject_image = VoidOutput(
+    "GDALReprojectImage",
+    argtypes=[
         c_void_p,
         c_char_p,
         c_void_p,
@@ -153,17 +158,17 @@ reproject_image = void_output(
         c_void_p,
     ],
 )
-auto_create_warped_vrt = voidptr_output(
-    std_call("GDALAutoCreateWarpedVRT"),
-    [c_void_p, c_char_p, c_char_p, c_int, c_double, c_void_p],
+auto_create_warped_vrt = VoidPtrOutput(
+    "GDALAutoCreateWarpedVRT",
+    argtypes=[c_void_p, c_char_p, c_char_p, c_int, c_double, c_void_p],
 )
 
 # Create VSI gdal raster files from in-memory buffers.
 # https://gdal.org/api/cpl.html#cpl-vsi-h
-create_vsi_file_from_mem_buffer = voidptr_output(
-    std_call("VSIFileFromMemBuffer"), [c_char_p, c_void_p, c_int, c_int]
+create_vsi_file_from_mem_buffer = VoidPtrOutput(
+    "VSIFileFromMemBuffer", argtypes=[c_char_p, c_void_p, c_int, c_int]
 )
-get_mem_buffer_from_vsi_file = voidptr_output(
-    std_call("VSIGetMemFileBuffer"), [c_char_p, POINTER(c_int), c_bool]
+get_mem_buffer_from_vsi_file = VoidPtrOutput(
+    "VSIGetMemFileBuffer", argtypes=[c_char_p, POINTER(c_int), c_bool]
 )
-unlink_vsi_file = int_output(std_call("VSIUnlink"), [c_char_p])
+unlink_vsi_file = IntOutput("VSIUnlink", argtypes=[c_char_p])

--- a/django/contrib/gis/gdal/prototypes/srs.py
+++ b/django/contrib/gis/gdal/prototypes/srs.py
@@ -1,107 +1,112 @@
 from ctypes import POINTER, c_char_p, c_int, c_void_p
 
-from django.contrib.gis.gdal.libgdal import lgdal, std_call
 from django.contrib.gis.gdal.prototypes.generation import (
-    const_string_output,
-    double_output,
-    int_output,
-    srs_output,
-    string_output,
-    void_output,
+    ConstStringOutput,
+    DoubleOutput,
+    IntOutput,
+    SRSOutput,
+    StringOutput,
+    VoidOutput,
 )
 
 
 # Shortcut generation for routines with known parameters.
-def srs_double(f):
+class SRSDouble(DoubleOutput):
     """
     Create a function prototype for the OSR routines that take
     the OSRSpatialReference object and return a double value.
     """
-    return double_output(f, [c_void_p, POINTER(c_int)], errcheck=True)
+
+    argtypes = [c_void_p, POINTER(c_int)]
+    errcheck = True
 
 
-def units_func(f):
+class UnitsFunc(DoubleOutput):
     """
-    Create a ctypes function prototype for OSR units functions, e.g.,
+    Create a function prototype for OSR units functions, e.g.,
     OSRGetAngularUnits, OSRGetLinearUnits.
     """
-    return double_output(f, [c_void_p, POINTER(c_char_p)], strarg=True)
+
+    argtypes = [c_void_p, POINTER(c_char_p)]
+
+    def __init__(self, func_name, **kwargs):
+        super().__init__(func_name, strarg=True, **kwargs)
 
 
 # Creation & destruction.
-clone_srs = srs_output(std_call("OSRClone"), [c_void_p])
-new_srs = srs_output(std_call("OSRNewSpatialReference"), [c_char_p])
-release_srs = void_output(lgdal.OSRRelease, [c_void_p], errcheck=False)
-destroy_srs = void_output(
-    std_call("OSRDestroySpatialReference"), [c_void_p], errcheck=False
+clone_srs = SRSOutput("OSRClone", argtypes=[c_void_p])
+new_srs = SRSOutput("OSRNewSpatialReference", argtypes=[c_char_p])
+release_srs = VoidOutput("OSRRelease", argtypes=[c_void_p], errcheck=False)
+destroy_srs = VoidOutput(
+    "OSRDestroySpatialReference", argtypes=[c_void_p], errcheck=False
 )
-srs_validate = void_output(lgdal.OSRValidate, [c_void_p])
-set_axis_strategy = void_output(
-    lgdal.OSRSetAxisMappingStrategy, [c_void_p, c_int], errcheck=False
+srs_validate = VoidOutput("OSRValidate", argtypes=[c_void_p])
+set_axis_strategy = VoidOutput(
+    "OSRSetAxisMappingStrategy", argtypes=[c_void_p, c_int], errcheck=False
 )
 
 # Getting the semi_major, semi_minor, and flattening functions.
-semi_major = srs_double(lgdal.OSRGetSemiMajor)
-semi_minor = srs_double(lgdal.OSRGetSemiMinor)
-invflattening = srs_double(lgdal.OSRGetInvFlattening)
+semi_major = SRSDouble("OSRGetSemiMajor")
+semi_minor = SRSDouble("OSRGetSemiMinor")
+invflattening = SRSDouble("OSRGetInvFlattening")
 
 # WKT, PROJ, EPSG, XML importation routines.
-from_wkt = void_output(lgdal.OSRImportFromWkt, [c_void_p, POINTER(c_char_p)])
-from_proj = void_output(lgdal.OSRImportFromProj4, [c_void_p, c_char_p])
-from_epsg = void_output(std_call("OSRImportFromEPSG"), [c_void_p, c_int])
-from_xml = void_output(lgdal.OSRImportFromXML, [c_void_p, c_char_p])
-from_user_input = void_output(std_call("OSRSetFromUserInput"), [c_void_p, c_char_p])
+from_wkt = VoidOutput("OSRImportFromWkt", argtypes=[c_void_p, POINTER(c_char_p)])
+from_proj = VoidOutput("OSRImportFromProj4", argtypes=[c_void_p, c_char_p])
+from_epsg = VoidOutput("OSRImportFromEPSG", argtypes=[c_void_p, c_int])
+from_xml = VoidOutput("OSRImportFromXML", argtypes=[c_void_p, c_char_p])
+from_user_input = VoidOutput("OSRSetFromUserInput", argtypes=[c_void_p, c_char_p])
 
 # Morphing to/from ESRI WKT.
-morph_to_esri = void_output(lgdal.OSRMorphToESRI, [c_void_p])
-morph_from_esri = void_output(lgdal.OSRMorphFromESRI, [c_void_p])
+morph_to_esri = VoidOutput("OSRMorphToESRI", argtypes=[c_void_p])
+morph_from_esri = VoidOutput("OSRMorphFromESRI", argtypes=[c_void_p])
 
 # Identifying the EPSG
-identify_epsg = void_output(lgdal.OSRAutoIdentifyEPSG, [c_void_p])
+identify_epsg = VoidOutput("OSRAutoIdentifyEPSG", argtypes=[c_void_p])
 
 # Getting the angular_units, linear_units functions
-linear_units = units_func(lgdal.OSRGetLinearUnits)
-angular_units = units_func(lgdal.OSRGetAngularUnits)
+linear_units = UnitsFunc("OSRGetLinearUnits")
+angular_units = UnitsFunc("OSRGetAngularUnits")
 
 # For exporting to WKT, PROJ, "Pretty" WKT, and XML.
-to_wkt = string_output(
-    std_call("OSRExportToWkt"), [c_void_p, POINTER(c_char_p)], decoding="utf-8"
+to_wkt = StringOutput(
+    "OSRExportToWkt", argtypes=[c_void_p, POINTER(c_char_p)], decoding="utf-8"
 )
-to_proj = string_output(
-    std_call("OSRExportToProj4"), [c_void_p, POINTER(c_char_p)], decoding="ascii"
+to_proj = StringOutput(
+    "OSRExportToProj4", argtypes=[c_void_p, POINTER(c_char_p)], decoding="ascii"
 )
-to_pretty_wkt = string_output(
-    std_call("OSRExportToPrettyWkt"),
-    [c_void_p, POINTER(c_char_p), c_int],
+to_pretty_wkt = StringOutput(
+    "OSRExportToPrettyWkt",
+    argtypes=[c_void_p, POINTER(c_char_p), c_int],
     offset=-2,
     decoding="utf-8",
 )
 
-to_xml = string_output(
-    lgdal.OSRExportToXML,
-    [c_void_p, POINTER(c_char_p), c_char_p],
+to_xml = StringOutput(
+    "OSRExportToXML",
+    argtypes=[c_void_p, POINTER(c_char_p), c_char_p],
     offset=-2,
     decoding="utf-8",
 )
 
 # String attribute retrieval routines.
-get_attr_value = const_string_output(
-    std_call("OSRGetAttrValue"), [c_void_p, c_char_p, c_int], decoding="utf-8"
+get_attr_value = ConstStringOutput(
+    "OSRGetAttrValue", argtypes=[c_void_p, c_char_p, c_int], decoding="utf-8"
 )
-get_auth_name = const_string_output(
-    lgdal.OSRGetAuthorityName, [c_void_p, c_char_p], decoding="ascii"
+get_auth_name = ConstStringOutput(
+    "OSRGetAuthorityName", argtypes=[c_void_p, c_char_p], decoding="ascii"
 )
-get_auth_code = const_string_output(
-    lgdal.OSRGetAuthorityCode, [c_void_p, c_char_p], decoding="ascii"
+get_auth_code = ConstStringOutput(
+    "OSRGetAuthorityCode", argtypes=[c_void_p, c_char_p], decoding="ascii"
 )
 
 # SRS Properties
-isgeographic = int_output(lgdal.OSRIsGeographic, [c_void_p])
-islocal = int_output(lgdal.OSRIsLocal, [c_void_p])
-isprojected = int_output(lgdal.OSRIsProjected, [c_void_p])
+isgeographic = IntOutput("OSRIsGeographic", argtypes=[c_void_p])
+islocal = IntOutput("OSRIsLocal", argtypes=[c_void_p])
+isprojected = IntOutput("OSRIsProjected", argtypes=[c_void_p])
 
 # Coordinate transformation
-new_ct = srs_output(std_call("OCTNewCoordinateTransformation"), [c_void_p, c_void_p])
-destroy_ct = void_output(
-    std_call("OCTDestroyCoordinateTransformation"), [c_void_p], errcheck=False
+new_ct = SRSOutput("OCTNewCoordinateTransformation", argtypes=[c_void_p, c_void_p])
+destroy_ct = VoidOutput(
+    "OCTDestroyCoordinateTransformation", argtypes=[c_void_p], errcheck=False
 )

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -728,12 +728,13 @@ class CaptureQueriesContext:
         self.connection.ensure_connection()
         self.initial_queries = len(self.connection.queries_log)
         self.final_queries = None
-        request_started.disconnect(reset_queries)
+        self.reset_queries_disconnected = request_started.disconnect(reset_queries)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.connection.force_debug_cursor = self.force_debug_cursor
-        request_started.connect(reset_queries)
+        if self.reset_queries_disconnected:
+            request_started.connect(reset_queries)
         if exc_type is not None:
             return
         self.final_queries = len(self.connection.queries_log)

--- a/tests/gis_tests/gdal_tests/tests.py
+++ b/tests/gis_tests/gdal_tests/tests.py
@@ -6,7 +6,9 @@ from django.contrib.gis.gdal import GDAL_VERSION, gdal_full_version, gdal_versio
 class GDALTest(unittest.TestCase):
     def test_gdal_version(self):
         if GDAL_VERSION:
-            self.assertEqual(gdal_version(), ("%s.%s.%s" % GDAL_VERSION).encode())
+            self.assertEqual(
+                gdal_version(), ("%s.%s.%s" % tuple(GDAL_VERSION)).encode()
+            )
         else:
             self.assertIn(b".", gdal_version())
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -435,6 +435,14 @@ class CaptureQueriesContextManagerTests(TestCase):
         self.assertIn(self.person_pk, captured_queries[0]["sql"])
         self.assertIn(self.person_pk, captured_queries[1]["sql"])
 
+    def test_with_client_nested(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            Person.objects.count()
+            with CaptureQueriesContext(connection):
+                pass
+            self.client.get(self.url)
+        self.assertEqual(2, len(captured_queries))
+
 
 @override_settings(ROOT_URLCONF="test_utils.urls")
 class AssertNumQueriesContextManagerTests(TestCase):
@@ -473,6 +481,13 @@ class AssertNumQueriesContextManagerTests(TestCase):
 
         with self.assertNumQueries(2):
             self.client.get(self.url)
+            self.client.get(self.url)
+
+    def test_with_client_nested(self):
+        with self.assertNumQueries(2):
+            Person.objects.count()
+            with self.assertNumQueries(0):
+                pass
             self.client.get(self.url)
 
 

--- a/tests/utils_tests/test_lazy_libgdal.py
+++ b/tests/utils_tests/test_lazy_libgdal.py
@@ -1,0 +1,152 @@
+import os
+import sys
+from unittest import mock, skipIf
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+from django.utils.functional import SimpleLazyObject, empty
+
+
+class GDALLazyLoadingTest(SimpleTestCase):
+    """
+    Testing for the lazy loading of the GDAL library - whether or not GDAL
+    is installed - verifying that:
+
+    - The GDAL library is not loaded upon importing `django.contrib.gis.gdal.libgdal`.
+    - The library is loaded only once upon the first access to an attribute
+      of the lazy object.
+    - Subsequent accesses do not reload the library.
+    - The lazy objects use the `empty` sentinel from `django.utils.functional`
+      to indicate whether the loading function has been called.
+    - Appropriate exceptions are raised when the GDAL library cannot be found.
+
+    The tests avoid dependency on the actual GDAL library by handling
+    `AttributeError` from accessing non-existent attributes and by mocking
+    where necessary.
+    """
+
+    def setUp(self):
+        # Clean up modules before each test
+        self.modules_to_clean = ["django.contrib.gis.gdal.libgdal"]
+        for module in self.modules_to_clean:
+            if module in sys.modules:
+                del sys.modules[module]
+
+    def tearDown(self):
+        # Clean up after test
+        for module in self.modules_to_clean:
+            if module in sys.modules:
+                del sys.modules[module]
+
+    def test_lgdal_not_loaded_on_import(self):
+        from django.contrib.gis.gdal import libgdal
+
+        self.assertIsInstance(libgdal.lgdal, SimpleLazyObject)
+        self.assertTrue(hasattr(libgdal.lgdal, "_wrapped"))
+        self.assertIs(libgdal.lgdal._wrapped, empty)
+
+    @skipIf(os.name != "nt", "lwingdal is Windows-specific")
+    def test_lwingdal_not_loaded_on_import(self):
+        from django.contrib.gis.gdal import libgdal
+
+        self.assertIsInstance(libgdal.lwingdal, SimpleLazyObject)
+        self.assertTrue(hasattr(libgdal.lwingdal, "_wrapped"))
+        self.assertIs(libgdal.lwingdal._wrapped, empty)
+
+    def test_lgdal_loaded_on_first_access(self):
+        from django.contrib.gis.gdal import libgdal
+
+        self.assertIs(libgdal.lgdal._wrapped, empty)
+
+        try:
+            # Try to access a non-existent attribute
+            # This should trigger the lazy loading
+            with self.assertRaises(AttributeError):
+                libgdal.lgdal.some_attribute
+
+            self.assertIsNot(libgdal.lgdal._wrapped, empty)
+        except ImproperlyConfigured:
+            # GDAL is not installed, but our wrapper worked
+            self.skipTest("GDAL is not installed")
+
+    @skipIf(os.name != "nt", "lwingdal is Windows-specific")
+    def test_lwingdal_loaded_on_first_access(self):
+        from django.contrib.gis.gdal import libgdal
+
+        self.assertIs(libgdal.lwingdal._wrapped, empty)
+
+        try:
+            # Try to access a non-existent attribute
+            # This should trigger the lazy loading
+            with self.assertRaises(AttributeError):
+                libgdal.lwingdal.some_attribute
+
+            self.assertIsNot(libgdal.lwingdal._wrapped, empty)
+        except ImproperlyConfigured:
+            # GDAL is not installed, but our wrapper worked
+            self.skipTest("GDAL is not installed")
+
+    def test_lgdal_load_is_cached(self):
+        from django.contrib.gis.gdal import libgdal
+
+        self.assertIs(libgdal.lgdal._wrapped, empty)
+
+        try:
+            # First access
+            with self.assertRaises(AttributeError):
+                libgdal.lgdal.some_attribute
+
+            first_loaded_object = libgdal.lgdal._wrapped
+            self.assertIsNot(first_loaded_object, empty)
+
+            # Second access
+            with self.assertRaises(AttributeError):
+                libgdal.lgdal.another_attribute
+
+            second_loaded_object = libgdal.lgdal._wrapped
+            self.assertIsNot(second_loaded_object, empty)
+            self.assertIs(second_loaded_object, first_loaded_object)
+        except ImproperlyConfigured:
+            # GDAL is not installed, but our wrapper worked
+            self.skipTest("GDAL is not installed")
+
+    @skipIf(os.name != "nt", "lwingdal is Windows-specific")
+    def test_lwingdal_load_is_cached(self):
+        from django.contrib.gis.gdal import libgdal
+
+        self.assertIs(libgdal.lwingdal._wrapped, empty)
+
+        try:
+            # First access
+            with self.assertRaises(AttributeError):
+                libgdal.lwingdal.some_attribute
+
+            first_loaded_object = libgdal.lwingdal._wrapped
+            self.assertIsNot(first_loaded_object, empty)
+
+            # Second access
+            with self.assertRaises(AttributeError):
+                libgdal.lwingdal.another_attribute
+
+            second_loaded_object = libgdal.lwingdal._wrapped
+            self.assertIsNot(second_loaded_object, empty)
+            self.assertIs(second_loaded_object, first_loaded_object)
+        except ImproperlyConfigured:
+            # GDAL is not installed, but our wrapper worked
+            self.skipTest("GDAL is not installed")
+
+    @mock.patch("ctypes.util.find_library")
+    def test_load_gdal_failure(self, mock_find_library):
+        mock_find_library.return_value = None
+
+        # Need to ensure the module is not already loaded
+        if "django.contrib.gis.gdal.libgdal" in sys.modules:
+            del sys.modules["django.contrib.gis.gdal.libgdal"]
+
+        from django.contrib.gis.gdal import libgdal
+
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, "Could not find the GDAL library"
+        ):
+            # Trigger the lazy loading
+            libgdal.lgdal.some_attribute

--- a/tests/utils_tests/test_lazy_libgdal.py
+++ b/tests/utils_tests/test_lazy_libgdal.py
@@ -1,8 +1,7 @@
 import os
 import sys
-from unittest import mock, skipIf
+from unittest import skipIf
 
-from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 from django.utils.functional import SimpleLazyObject, empty
 
@@ -13,30 +12,17 @@ class GDALLazyLoadingTest(SimpleTestCase):
     is installed - verifying that:
 
     - The GDAL library is not loaded upon importing `django.contrib.gis.gdal.libgdal`.
-    - The library is loaded only once upon the first access to an attribute
-      of the lazy object.
-    - Subsequent accesses do not reload the library.
-    - The lazy objects use the `empty` sentinel from `django.utils.functional`
-      to indicate whether the loading function has been called.
-    - Appropriate exceptions are raised when the GDAL library cannot be found.
+    - The library loading is attempted when the lazy object is accessed.
 
-    The tests avoid dependency on the actual GDAL library by handling
-    `AttributeError` from accessing non-existent attributes and by mocking
-    where necessary.
+    The tests work regardless of whether GDAL is installed by tracking
+    whether the load function is called, not whether it succeeds.
     """
 
     def setUp(self):
-        # Clean up modules before each test
-        self.modules_to_clean = ["django.contrib.gis.gdal.libgdal"]
-        for module in self.modules_to_clean:
-            if module in sys.modules:
-                del sys.modules[module]
+        libgdal_mod = "django.contrib.gis.gdal.libgdal"
 
-    def tearDown(self):
-        # Clean up after test
-        for module in self.modules_to_clean:
-            if module in sys.modules:
-                del sys.modules[module]
+        if libgdal_mod in sys.modules:
+            del sys.modules[libgdal_mod]
 
     def test_lgdal_not_loaded_on_import(self):
         from django.contrib.gis.gdal import libgdal
@@ -58,16 +44,26 @@ class GDALLazyLoadingTest(SimpleTestCase):
 
         self.assertIs(libgdal.lgdal._wrapped, empty)
 
-        try:
-            # Try to access a non-existent attribute
-            # This should trigger the lazy loading
-            with self.assertRaises(AttributeError):
-                libgdal.lgdal.some_attribute
+        load_called = False
+        lgdal_setupfunc = libgdal.lgdal.__dict__["_setupfunc"]
 
-            self.assertIsNot(libgdal.lgdal._wrapped, empty)
-        except ImproperlyConfigured:
-            # GDAL is not installed, but our wrapper worked
-            self.skipTest("GDAL is not installed")
+        def track_load():
+            nonlocal load_called
+            load_called = True
+            return lgdal_setupfunc()
+
+        # Modify __dict__ directly to avoid triggering lazy loading
+        libgdal.lgdal.__dict__["_setupfunc"] = track_load
+
+        try:
+            libgdal.lgdal["GDALOpen"]
+        except Exception:
+            # Don't care if it fails, just that it tried
+            pass
+        finally:
+            libgdal.lgdal.__dict__["_setupfunc"] = lgdal_setupfunc
+
+        self.assertTrue(load_called)
 
     @skipIf(os.name != "nt", "lwingdal is Windows-specific")
     def test_lwingdal_loaded_on_first_access(self):
@@ -75,78 +71,24 @@ class GDALLazyLoadingTest(SimpleTestCase):
 
         self.assertIs(libgdal.lwingdal._wrapped, empty)
 
-        try:
-            # Try to access a non-existent attribute
-            # This should trigger the lazy loading
-            with self.assertRaises(AttributeError):
-                libgdal.lwingdal.some_attribute
+        load_called = False
+        lwingdal_setupfunc = libgdal.lwingdal.__dict__["_setupfunc"]
 
-            self.assertIsNot(libgdal.lwingdal._wrapped, empty)
-        except ImproperlyConfigured:
-            # GDAL is not installed, but our wrapper worked
-            self.skipTest("GDAL is not installed")
+        def track_load():
+            nonlocal load_called
+            load_called = True
+            return lwingdal_setupfunc()
 
-    def test_lgdal_load_is_cached(self):
-        from django.contrib.gis.gdal import libgdal
-
-        self.assertIs(libgdal.lgdal._wrapped, empty)
+        # Modify __dict__ directly to avoid triggering lazy loading
+        libgdal.lwingdal.__dict__["_setupfunc"] = track_load
 
         try:
-            # First access
-            with self.assertRaises(AttributeError):
-                libgdal.lgdal.some_attribute
+            # Access lwingdal to trigger loading
+            libgdal.lwingdal["OSRNewSpatialReference"]
+        except Exception:
+            # Don't care if it fails, just that it tried
+            pass
+        finally:
+            libgdal.lwingdal.__dict__["_setupfunc"] = lwingdal_setupfunc
 
-            first_loaded_object = libgdal.lgdal._wrapped
-            self.assertIsNot(first_loaded_object, empty)
-
-            # Second access
-            with self.assertRaises(AttributeError):
-                libgdal.lgdal.another_attribute
-
-            second_loaded_object = libgdal.lgdal._wrapped
-            self.assertIsNot(second_loaded_object, empty)
-            self.assertIs(second_loaded_object, first_loaded_object)
-        except ImproperlyConfigured:
-            # GDAL is not installed, but our wrapper worked
-            self.skipTest("GDAL is not installed")
-
-    @skipIf(os.name != "nt", "lwingdal is Windows-specific")
-    def test_lwingdal_load_is_cached(self):
-        from django.contrib.gis.gdal import libgdal
-
-        self.assertIs(libgdal.lwingdal._wrapped, empty)
-
-        try:
-            # First access
-            with self.assertRaises(AttributeError):
-                libgdal.lwingdal.some_attribute
-
-            first_loaded_object = libgdal.lwingdal._wrapped
-            self.assertIsNot(first_loaded_object, empty)
-
-            # Second access
-            with self.assertRaises(AttributeError):
-                libgdal.lwingdal.another_attribute
-
-            second_loaded_object = libgdal.lwingdal._wrapped
-            self.assertIsNot(second_loaded_object, empty)
-            self.assertIs(second_loaded_object, first_loaded_object)
-        except ImproperlyConfigured:
-            # GDAL is not installed, but our wrapper worked
-            self.skipTest("GDAL is not installed")
-
-    @mock.patch("ctypes.util.find_library")
-    def test_load_gdal_failure(self, mock_find_library):
-        mock_find_library.return_value = None
-
-        # Need to ensure the module is not already loaded
-        if "django.contrib.gis.gdal.libgdal" in sys.modules:
-            del sys.modules["django.contrib.gis.gdal.libgdal"]
-
-        from django.contrib.gis.gdal import libgdal
-
-        with self.assertRaisesMessage(
-            ImproperlyConfigured, "Could not find the GDAL library"
-        ):
-            # Trigger the lazy loading
-            libgdal.lgdal.some_attribute
+        self.assertTrue(load_called)


### PR DESCRIPTION
GDAL is now loaded only when first access rather than at import time, mirroring the approach taken for GEOS.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-XXXXX

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
